### PR TITLE
chore(package): move to sergile org

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-convert.js
-names.csv

--- a/cli.js
+++ b/cli.js
@@ -82,8 +82,9 @@ function nextName () {
     if (argv.f || names.length) {
       if (!argv.b) process.stdout.write('... ')
       nextName()
+    } else {
+      console.log()
     }
-    else console.log()
   }, argv.interval)
 }
 

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "random-int": "^1.0.0",
     "unique-random-array": "^1.0.0",
     "yargonaut": "^1.1.2",
-    "yargs": "^4.2.0"
+    "yargs": "^4.6.0"
   },
   "devDependencies": {
     "jsonfile": "^2.2.3",
     "linebyline": "^1.2.1",
-    "standard": "^5.4.1",
+    "standard": "^6.0.8",
     "standard-version": "^2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "words.json"
   ],
   "scripts": {
-    "test": "standard"
+    "test": "standard",
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "jsonfile": "^2.2.3",
     "linebyline": "^1.2.1",
-    "standard": "^5.4.1"
+    "standard": "^5.4.1",
+    "standard-version": "^2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nexdrew/alain.git"
+    "url": "git+https://github.com/sergile/alain.git"
   },
   "keywords": [
     "app",
@@ -33,9 +33,9 @@
   "author": "nexdrew",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/nexdrew/alain/issues"
+    "url": "https://github.com/sergile/alain/issues"
   },
-  "homepage": "https://github.com/nexdrew/alain#readme",
+  "homepage": "https://github.com/sergile/alain#readme",
   "dependencies": {
     "es6-promise": "^3.0.2",
     "random-int": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "random-int": "^1.0.0",
     "unique-random-array": "^1.0.0",
     "yargonaut": "^1.1.2",
-    "yargs": "^4.6.0"
+    "yargs": "^4.7.0"
   },
   "devDependencies": {
-    "jsonfile": "^2.2.3",
+    "jsonfile": "^2.3.0",
     "linebyline": "^1.2.1",
-    "standard": "^6.0.8",
-    "standard-version": "^2.1.2"
+    "standard": "^7.0.1",
+    "standard-version": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "bin": {
     "alain": "cli.js"
   },
+  "files": [
+    "cli.js",
+    "index.js",
+    "words.json"
+  ],
   "scripts": {
     "test": "standard"
   },


### PR DESCRIPTION
Various maintenance and cleanup:
- Move to sergile org
- Updates dependencies
- Opt for `"files"` whitelist in _package.json_ instead of _.npmignore_ blacklist
- Add `standard-version` (`npm run release`) as a better replacement for `npm version`

reviewers: @brad-bowie @jonirons 
